### PR TITLE
Extend sqlfuzz with showtable function

### DIFF
--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -18,8 +18,8 @@ func (m MySQL) Driver() string {
 }
 
 func (m MySQL) Insert(fields []string, table string) string {
-	var template = "INSERT INTO %s(%s) VALUES(%s)"
-	return fmt.Sprintf(template, table, strings.Join(fields, ", "), questionMarks(len(fields)))
+	var template = "INSERT INTO %s(`%s`) VALUES(%s)"
+	return fmt.Sprintf(template, table, strings.Join(fields, "`,`"), questionMarks(len(fields)))
 }
 
 func (m MySQL) MapField(field string) Field {
@@ -134,5 +134,5 @@ func questionMarks(n int) string {
 		q = append(q, "?")
 	}
 
-	return strings.Join(q, ", ")
+	return strings.Join(q, ",")
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 		tables = []string{f.Table}
 	}
 	for _, table := range tables {
+		f.Table = table
 		fields, err := descriptor.Describe(db, table)
 		if err != nil {
 			log.Fatal(err.Error())

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,7 @@ func TestFuzz(t *testing.T) {
 
 	gofakeit.Seed(0)
 	db := connector.Connection(drivers.New(flags.Get().Driver))
-	fields, err := descriptor.Describe(db, f)
+	fields, err := descriptor.Describe(db, f.Table)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -23,10 +23,12 @@ func Insert(db *sql.DB, fields []descriptor.FieldDescriptor, driver drivers.Driv
 
 		values = append(values, generateData(driver, field.Type))
 	}
-	driver.Insert(f, table)
-	ins, err := db.Prepare(driver.Insert(f, table))
+	query := driver.Insert(f, table)
+
+	ins, err := db.Prepare(query)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("invalid preparing query: %s\n", query)
+		return fmt.Errorf("error preparing query: %w", err)
 	}
 
 	_, err = ins.Exec(values...)
@@ -73,7 +75,8 @@ func generateData(driver drivers.Driver, t string) interface{} {
 	case drivers.Time:
 		return gofakeit.Date()
 	case drivers.Unknown:
-		log.Fatalf("Unknown field type: %s", t)
+		log.Printf("unknown field type: %s\n", t)
+		return nil
 	}
 
 	return nil

--- a/pkg/descriptor/descriptor.go
+++ b/pkg/descriptor/descriptor.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/PumpkinSeed/sqlfuzz/pkg/flags"
 	"github.com/volatiletech/null"
 )
 
@@ -19,8 +18,8 @@ type FieldDescriptor struct {
 }
 
 // Describe try to get the fields of the table in the SQL database
-func Describe(db *sql.DB, f flags.Flags) ([]FieldDescriptor, error) {
-	results, err := db.Query(fmt.Sprintf("DESCRIBE %s;", f.Table))
+func Describe(db *sql.DB, table string) ([]FieldDescriptor, error) {
+	results, err := db.Query(fmt.Sprintf("DESCRIBE %s;", table))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/descriptor/tables.go
+++ b/pkg/descriptor/tables.go
@@ -1,0 +1,23 @@
+package descriptor
+
+import (
+	"database/sql"
+)
+
+func ShowTables(db *sql.DB) ([]string, error) {
+	results, err := db.Query("SHOW TABLES;")
+	if err != nil {
+		return nil, err
+	}
+	defer results.Close()
+	var tables []string
+	for results.Next() {
+		var table string
+		if err := results.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+
+	return tables, nil
+}


### PR DESCRIPTION
This makes `--table` flag optional and if not set, the app will be able to fetch the existing tables with SQL `show tables;` and run through them and process the fuzzer.