### PR TITLE
Fix typo in error messages

### DIFF
--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -262,7 +262,7 @@ func (MySQL) GetTestCase(name string) (types.TestCase, error) {
 	if val, ok := mySQLNameToTestCase[name]; ok {
 		return val, nil
 	}
-	return types.TestCase{}, fmt.Errorf("postgres: Error getting testcase with name %v", name)
+	return types.TestCase{}, fmt.Errorf("mysql: Error getting testcase with name %v", name)
 }
 
 func parseMySQLFields(results, fkRows *sql.Rows) ([]types.FieldDescriptor, error) {


### PR DESCRIPTION
SSAI
It only might had been forgotten to fix this message which might had been copied from `postgres`, though I'm not sure in detail.